### PR TITLE
Add install docs & fix typos in doc-strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,16 @@ Name | Description
 
 ## Installing this collection
 
-You can install the AWS collection with the Ansible Galaxy CLI:
+You can install the memsource collection with the Ansible Galaxy CLI:
 
 ```sh
 #> ansible-galaxy collection install community.memsource
+```
+
+To install directly from GitHub:
+
+```sh
+#> ansible-galaxy collection install git@github.com:ansible/ansible-collection-memsource.git
 ```
 
 You can also include it in a `requirements.yml` file and install it with `ansible-galaxy collection install -r requirements.yml`, using the format:

--- a/plugins/modules/memsource_job.py
+++ b/plugins/modules/memsource_job.py
@@ -26,7 +26,7 @@ options:
     description:
       - Source language of the job
     type: str
-  target_langs:
+  langs:
     description:
       - Target languages for the job
     type: list
@@ -41,9 +41,8 @@ EXAMPLES = """
 #
 - name: Create job
   community.memsource.memsource_job:
-    name: My Project
-    source_lang: en_us
-    target_langs:
+    project_uid: project_uid
+    langs:
       - ja_jp
       - zh_cn
     filename: /path/to/file
@@ -56,7 +55,7 @@ EXAMPLES = """
 - name: Delete job
   community.memsource.memsource_job:
     uid: uid
-    projectu_id: project_uid
+    project_uid: project_uid
     state: absent
 """
 

--- a/plugins/modules/memsource_job_targetfile.py
+++ b/plugins/modules/memsource_job_targetfile.py
@@ -44,19 +44,19 @@ requirements: [memsource]
 
 EXAMPLES = """
 - name: Download job target file and rely on filename and original directory name for dest
-  community.memsource.memsource_job_file:
+  community.memsource.memsource_job_targetfile:
     project_uid: xxx
     jobs_uid: yyy
 
 - name: Download job target file and write it in path
-  community.memsource.memsource_job_file:
+  community.memsource.memsource_job_targetfile:
     project_uid: xxx
     jobs_uid: yyy
     path: /tmp/foo
 """
 
 RETURN = """
-job_file:
+job_targetfile:
     returned: on success
     description: >
         TBD


### PR DESCRIPTION
* Add some notes on how to install the collection directly from GitHub.  
* Currently, it is not possible to specify a project name as best I can tell, instead, a project_uid needs to be specified.  This is updated in the doc strings
* Change name of `memsource_job_targetfile` for consistency with the file name of the module.
* `langs` is used, not `target_langs`, docs and examples are updated.  