### PR TITLE
preTranslate Flag & bug fix for retrieving job files from memsource.

### DIFF
--- a/plugins/modules/memsource_job.py
+++ b/plugins/modules/memsource_job.py
@@ -30,6 +30,9 @@ options:
     description:
       - Target languages for the job
     type: list
+  preTranslate:
+    description:
+      - Adds a flag to pre-populate data with cached strings
 extends_documentation_fragment:
 - community.memsource.memsource
 
@@ -87,6 +90,7 @@ def main():
             use_project_file_import_settings=dict(type="bool"),
             purge_on_delete=dict(type="bool"),
             split_filename_on_dir=dict(type="bool"),
+            preTranslate=dict(type="bool"),
             state=dict(type="str", default="present", choices=["absent", "present"]),
         ),
     )
@@ -109,6 +113,7 @@ def main():
             module.params.get("langs"),
             module.params.get("filename"),
             module.params.get("split_filename_on_dir", False),
+            module.params.get("preTranslate", True),
             **kwargs
         )
         _result.update({"changed": True})

--- a/plugins/modules/memsource_job_targetfile.py
+++ b/plugins/modules/memsource_job_targetfile.py
@@ -105,7 +105,7 @@ def main():
     if os.path.exists(_dest) and not module.params.get("force", False):
         pass
     else:
-        content = "%s\n" % str(res.content.decode("utf-8")).split("\n\r\n")[1]
+        content = "%s\n" % str(res.content.decode("utf-8")).split("\n\r\n")[0]
         with open(_dest, "w+") as ftw:
             ftw.write(content)
         _result.update({"changed": True})


### PR DESCRIPTION

Two code changes applicable.

1. preTranslate - preTranslate feature has been added to the script for enabling selection to preTranslate the strings being posted to Memsource.

2. Bug fix for retrieved strings - On changing the post request for uploading files to memsource without headers, the string being retrieved and split, initially consisted of headers which doesn't anymore. So the 0th element is now retrieving the string wherein initially 0th element consisted the headers.
https://github.com/ansible/python-memsource/pull/5/commits/f076af9e63f2478d87319e5207fb5dad59ace3eb