### PR TITLE
Added translations_langs var to the task

### DIFF
--- a/extra_vars.yml
+++ b/extra_vars.yml
@@ -10,4 +10,4 @@ project_name: ""
 project_template: 
 memsource_username: ""
 memsource_password: ""
-translation_supported_langs:
+languages:

--- a/roles/post_translation/README.md
+++ b/roles/post_translation/README.md
@@ -19,7 +19,7 @@ Below are the mandatory variables required.
 - repo_url - (Type: str)
 - repo_branch - (Type: str)
 - fork_repo_url - (Type: str) (Please note, a fork of the main repository URL should already be present for the github_username specified)
-- translation_supported_langs - (Type: list)
+- languages - (Type: list)
 - shell_script_path (Default (/tools/scripts/l18n/post_translation.sh) - can be overridden) (Type: str)
 - project_name - (Type: str) (Optional: Either pass project_name or project_uid)
 - project_uid - (Type: int) (Optional) - (WARNING: Do not include in pre_translation role as it will

--- a/roles/post_translation/defaults/main.yml
+++ b/roles/post_translation/defaults/main.yml
@@ -2,7 +2,7 @@
 memsource_username: "{{ lookup('env', 'MEMSOURCE_USERNAME') }}"
 memsource_password: "{{ lookup('env', 'MEMSOURCE_PASSWORD') }}"
 shell_script_path: "/tools/scripts/l18n/post_translation.sh"
-translation_supported_langs:
+languages:
 github_username: ""
 github_token: ""
 repo_url: ""

--- a/roles/post_translation/tasks/move_translated_strings.yml
+++ b/roles/post_translation/tasks/move_translated_strings.yml
@@ -34,10 +34,15 @@
   args:
     chdir: "{{ clone_directory.path }}"
 
-- name: Copy translations directory to _clones
+- name: Create translations directory
+  file:
+    path: "{{ clone_directory.path }}/translations"
+    state: directory
+
+- name: Loop over translation languages & copy translations directory to _clones
   shell: |
-    mv {{ role_path }}/files/_translations/{{ component }} {{ role_path }}/files/_clones/{{ component }}/translations
-  register: move_translations      
+    mv {{ role_path }}/files/_translations/{{ component }}/{{ item }} {{ role_path }}/files/_clones/{{ component }}/translations/
+  with_items: "{{ languages | default('*') }}"
 
 - name: Pre_translation shell script
   block:

--- a/roles/pre_translation/README.md
+++ b/roles/pre_translation/README.md
@@ -14,7 +14,7 @@ Role Variables
 Below are the mandatory variables required.
 - memsource_username (Can be provided from the command-line, vars file or can be set in environment variables) - (Type: str)
 - memsource_password (Can be provided from the command-line, vars file or can be set in environment variables) - (Type: str)
-- translation_supported_langs - (Type: list)
+- languages - (Type: list)
 - shell_script_path (Default (/tools/scripts/l18n/pre_translation.sh) - can be overridden) (Type: str)
 - repo_url - (Type: str)
 - repo_branch - (Type: str)

--- a/roles/pre_translation/defaults/main.yml
+++ b/roles/pre_translation/defaults/main.yml
@@ -2,7 +2,7 @@
 memsource_username: "{{ lookup('env', 'MEMSOURCE_USERNAME') }}"
 memsource_password: "{{ lookup('env', 'MEMSOURCE_PASSWORD') }}"
 shell_script_path: "/tools/scripts/l18n/pre_translation.sh"
-translation_supported_langs:
+languages:
 preTranslate: true
 repo_url: ""
 repo_branch: ""

--- a/roles/pre_translation/tasks/upload_strings_to_memsource.yml
+++ b/roles/pre_translation/tasks/upload_strings_to_memsource.yml
@@ -46,7 +46,7 @@
   - name: Upload files to jobs on project
     ansible.memsource.memsource_job:
       project_uid: "{{ project_uid }}"
-      langs: "{{ translation_supported_langs }}"
+      langs: "{{ languages }}"
       filename: "{{ role_path }}/files/_clones/{{ component }}/translations/{{ item }}"
       preTranslate: "{{ preTranslate }}"
       memsource_username: "{{ memsource_username }}"


### PR DESCRIPTION
Initially, when we pulled strings from a memsource project, we were able to pull all available languages strings from the memsource project and push it to the repository or filter only one language.

This PR is a fix where we can filter one or more languages as providing it as a list of langs.