### PR TITLE
Honor project_uid if specified when pulling strings

### DIFF
--- a/roles/post_translation/tasks/download_from_memsource.yml
+++ b/roles/post_translation/tasks/download_from_memsource.yml
@@ -25,6 +25,7 @@
 - name: Set Project UID from project name
   ansible.builtin.set_fact:
     project_uid: "{{ _project.projects.content[0].uid }}"
+  when: project_uid is not defined
 
 - name: Gather information about a specific job
   ansible.memsource.memsource_job_info:


### PR DESCRIPTION
Currently, even if the project_uid is specified, it is just ignored and the post_translation role attempts to get the project_uid based on the name of project (provided via `project_name`).  

We should preferentially use project_uid when specified as it is a more specific and reliable way to specify the project to use.  