### PR TITLE
Correct a couple small docs typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The python module dependencies are not installed by `ansible-galaxy`.  They can
 be manually installed using pip:
 
 ```sh
-#> pip install requirements.txt
+#> pip install -r requirements.txt
 ```
 
 or:

--- a/roles/post_translation/README.md
+++ b/roles/post_translation/README.md
@@ -63,7 +63,7 @@ Execution Steps
 An Ansible Playbook (pull.yml) will be used to run this role.
 
 1. Provide the required variables from the command-line as per the below example \
-    ```ansible-playbook playbooks/pull.yml -e memsource_username=$MEMSOURCE_USERNAME -e memsource_password=$MEMSOURCE_PASSWORD -e repo_url="test_repo/prod" -e repo_branch="devel" -e repo_url="test_repo/test" -e project_name="MEMSOURCE TRANSLATION PROJECT V2.1"``` \
+    ```ansible-playbook playbooks/pull.yml -e memsource_username=$MEMSOURCE_USERNAME -e memsource_password=$MEMSOURCE_PASSWORD -e repo_url="test_repo/prod" -e repo_branch="devel" -e project_name="MEMSOURCE TRANSLATION PROJECT V2.1"``` \
     or \
     Another way of providing vars using the command-line can be using a separate yml file (e.g. extra_vars.yml, template is available on the root path) \
     ```ansible-playbook playbooks/pull.yml -e @extra_vars.yml```

--- a/roles/pre_translation/README.md
+++ b/roles/pre_translation/README.md
@@ -52,7 +52,7 @@ Execution Steps
 Ansible Playbook (push.yml) will be used to run this role.
 
 1. Provide the required variables from the command-line as per the below example \
-   ```ansible-playbook playbooks/push.yml -e memsource_username=$MEMSOURCE_USERNAME -e memsource_password=$MEMSOURCE_PASSWORD -e repo_url="test_repo/prod" -e repo_branch="devel" -e project_name="Memsource Test Project" -e preTranslae=false -e project_template=310943``` \
+   ```ansible-playbook playbooks/push.yml -e memsource_username=$MEMSOURCE_USERNAME -e memsource_password=$MEMSOURCE_PASSWORD -e repo_url="test_repo/prod" -e repo_branch="devel" -e project_name="Memsource Test Project" -e preTranslate=false -e project_template=310943``` \
    or \
    Another way of providing vars using the command-line can be using a separate yml file (e.g. extra_vars.yml) \
    ```ansible-playbook playbooks/push.yml -e @extra_vars.yml```


### PR DESCRIPTION
* repo_url is not needed
* `-r` is needed when pip installing from a file, otherwise the command fails.  