### PR TITLE
Add Ansible Lint config file to exclude workflows dir

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,17 @@
+---
+# .ansible-lint
+# exclude_paths included in this file are parsed relative to this file's location
+# and not relative to the CWD of execution. CLI arguments passed to the --exclude
+# option will be parsed relative to the CWD of execution.
+exclude_paths:
+  - .cache/
+  - .github/
+  - roles/pre_translation/files/_clones
+  - roles/post_translation/files/_clones
+
+# parseable: true
+# quiet: true
+# strict: true
+# verbosity: 1
+
+use_default_rules: true

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Run ansible-lint
         uses: ansible-community/ansible-lint-action@main

--- a/roles/post_translation/tasks/main.yml
+++ b/roles/post_translation/tasks/main.yml
@@ -11,13 +11,13 @@
       - project_name | default('') | length
 
 - name: Download strings from Memsource
-  include_tasks: download_from_memsource.yml
+  ansible.builtin.include_tasks: download_from_memsource.yml
 
 - name: Run post_translation shell script
-  include_tasks: move_translated_strings.yml
+  ansible.builtin.include_tasks: move_translated_strings.yml
 
 - name: Upload to Repository
-  include_tasks: push_strings.yml
+  ansible.builtin.include_tasks: push_strings.yml
 
 - name: Cleanup
-  include_tasks: "cleanup.yml"
+  ansible.builtin.include_tasks: "cleanup.yml"

--- a/roles/post_translation/tasks/push_strings.yml
+++ b/roles/post_translation/tasks/push_strings.yml
@@ -13,8 +13,8 @@
   ansible.builtin.shell: |
     gh pr create --head {{ github_username }}:{{ pr_branch }} --fill --base {{ repo_branch }} --repo {{ repo_url }}
   environment:
-    GITHUB_USERNAME: '{{ github_username }}' # Default credentials will be retrieved from GitHub SSH Key
-    GITHUB_TOKEN: '{{ github_token }}' # Default credentials will be retrieved from GitHub SSH Key
+    GITHUB_USERNAME: '{{ github_username }}'  # Default credentials will be retrieved from GitHub SSH Key
+    GITHUB_TOKEN: '{{ github_token }}'  # Default credentials will be retrieved from GitHub SSH Key
   changed_when: false
   args:
     chdir: '{{ clone_directory.path }}'

--- a/roles/pre_translation/tasks/main.yml
+++ b/roles/pre_translation/tasks/main.yml
@@ -10,10 +10,10 @@
       - project_template | type_debug == "int"
 
 - name: Start with extracting strings from project
-  include_tasks: extract_strings.yml
+  ansible.builtin.include_tasks: extract_strings.yml
 
 - name: Upload to Memsource
-  include_tasks: upload_strings_to_memsource.yml
+  ansible.builtin.include_tasks: upload_strings_to_memsource.yml
 
 - name: Cleanup
-  include_tasks: "cleanup.yml"
+  ansible.builtin.include_tasks: "cleanup.yml"


### PR DESCRIPTION
Add basic ansible lint config to make local lint runs pass when project clones exists in the `_clones` directories.  

Also, fix fqdn lint failures.  