### PR TITLE
Handle case where project_uid is an empty string

### DIFF
--- a/roles/post_translation/tasks/download_from_memsource.yml
+++ b/roles/post_translation/tasks/download_from_memsource.yml
@@ -25,7 +25,8 @@
 - name: Set Project UID from project name
   ansible.builtin.set_fact:
     project_uid: "{{ _project.projects.content[0].uid }}"
-  when: project_uid is not defined
+  when:
+    - project_uid is not defined or not project_uid | length
 
 - name: Gather information about a specific job
   ansible.memsource.memsource_job_info:


### PR DESCRIPTION
This PR made it possible to override a dynamically grabbed project_uid:
* https://github.com/ansible/ansible-collection-memsource/pull/40

It did not take into account that the default is an empty string though.  This PR fixes that.  