### PR TITLE
Pre_Translation repo changed from upstream repo to forked repo

### DIFF
--- a/roles/post_translation/README.md
+++ b/roles/post_translation/README.md
@@ -34,7 +34,7 @@ Dependencies
 
 Steps to create post_translation shell Script
 --------------------------------------------
-- Create a post_translation.sh file. This file will reside in the project which will be used for translation in the root path as per below e.g.
+- Create a post_translation.sh file. This file will reside in the project (**forked repository**) which will be used for translation in the root path as per below e.g.
 **/tools/scripts/l18n/post_translation.sh**
 Note: The file can be stored in other directories as well, you need to specify the path in the var shell_script_path to override the default path for the shell script (Reference the var in the default/main.yml file)
 - A translations folder will be provided with all the translated strings retrieved from Memsource (folder name: translations)\

--- a/roles/pre_translation/README.md
+++ b/roles/pre_translation/README.md
@@ -29,7 +29,7 @@ Global vars are declared in the defaults folder as main.yml which can be overrid
 
 Steps to create pre_translation shell Script
 --------------------------------------------
-- Create a pre_translation.sh file. This file will reside in the project which will be used for translation in the root path as per below
+- Create a pre_translation.sh file. This file will reside in the project (**forked repository**) which will be used for translation in the root path as per below
 **/tools/scripts/l18n/pre_translation.sh**
 Note: File can be stored in other directories as well, you need to specify the path in the var shell_script_path to override the default path for the shell script (Reference the var in the default/main.yml file)
 - Add the execution commands to extract the files (e.g. po, json)

--- a/roles/pre_translation/tasks/extract_strings.yml
+++ b/roles/pre_translation/tasks/extract_strings.yml
@@ -20,15 +20,19 @@
     state: directory
     name: "{{ role_path }}/files/_clones/{{ component }}"
     mode: 0775
-  register: clone_repo_path
+  register: clone_directory
 
-- name: Cloned Repository Directory (From Repository - latest changes)
+- name: Clone the repository
   ansible.builtin.git:
-    repo: 'git@github.com:{{ repo_url }}.git'
-    dest: '{{ clone_repo_path.path }}'
+    repo: 'git@github.com:{{ fork_repo_url }}.git'
+    dest: '{{ clone_directory.path }}'
     version: '{{ repo_branch }}'
     force: true
     depth: 1
+
+- name: Fetch Upstream for changes
+  ansible.builtin.shell: cd {{ clone_directory.path }} && git pull --rebase git@github.com:{{ repo_url }}.git {{ repo_branch }}
+  changed_when: false
 
 - name: Temporary Strings Storage Directory in repository
   ansible.builtin.file:


### PR DESCRIPTION
The change for the pre_translation goes as below.

Initially, we were cloning the main repo (e.g. ansible/galaxy_ng) as per the playbook and the pre_translation script was supposedly be residing in the same repo.

But now, we are cloning the forked repo (e.g. adityamulik/galaxy_ng) and then we are fetching/ rebasing with the main repo here (e.g. ansible/galaxy_ng) and extracting the strings from the forked repo which are later uploaded to Memsource.

This helps us to keep the shell scripts (pre_translation/ post_translation.sh) in the forked repo itself and not in the main repo.
**_The implementation is already in place for the post_translation role._** (Ref: https://github.com/adityamulik/ansible-collection-memsource/blob/367bf266d01f1d6885afade6a61586d70312ace1/roles/post_translation/tasks/move_translated_strings.yml#L22)

Considering the above being done, we would require to add 
pre_translation.sh
post_translation.sh 

to the ansible/galaxy_ng -> .gitignore

That would help us, when we are pushing back the translated strings once retrieved from memsource, these shell scripts don't get added to the PR which is supposed to push back the strings.