### PR TITLE
Cast project_template to int when used

### DIFF
--- a/roles/pre_translation/tasks/main.yml
+++ b/roles/pre_translation/tasks/main.yml
@@ -7,7 +7,7 @@
       - repo_url | default('') | length
       - repo_branch | default('') | length
       - project_name | default('') | length
-      - project_template | type_debug == "int"
+      - project_template | default('') | length
 
 - name: Start with extracting strings from project
   ansible.builtin.include_tasks: extract_strings.yml

--- a/roles/pre_translation/tasks/upload_strings_to_memsource.yml
+++ b/roles/pre_translation/tasks/upload_strings_to_memsource.yml
@@ -5,7 +5,7 @@
   - name: Create Project from Template ID
     ansible.memsource.memsource_project:
       name: "{{ project_name }}"
-      template_id: "{{ project_template }}"
+      template_id: "{{ project_template | int }}"
       memsource_username: "{{ memsource_username }}"
       memsource_password: "{{ memsource_password }}"
     register: _project


### PR DESCRIPTION
  * the assert now just checks that the variable is set
  * now str or int can be passed and it will just work

Before this change, it was impossible to supply the project_template value via an extra variable at the command line because no matter how you pass it (quotes or not) it is interpretted as a string.  


The following didn't work.  With this change, they both work.  
```
-e project_template=194113 \
```

and

```
-e project_template="194113" \
```