### PR TITLE
Print Project URL after pushing strings to a Memsource Project

### DIFF
--- a/roles/pre_translation/tasks/upload_strings_to_memsource.yml
+++ b/roles/pre_translation/tasks/upload_strings_to_memsource.yml
@@ -56,3 +56,7 @@
         memsource_password: "{{ memsource_password }}"
       loop: "{{ translation_files }}"
       register: _job
+
+- name: Print Project URL
+  ansible.builtin.debug:
+    msg: "{{ project_urls }}"


### PR DESCRIPTION
Print Project URL after pushing strings to a Memsource Project for convenience.  

It is useful to have a quick link:

![image](https://user-images.githubusercontent.com/11698892/198675336-8202b886-1b59-4d00-8e80-dd1755abe420.png)