### PR TITLE
Fix error when script does not exist in repo

### DIFF
--- a/roles/post_translation/tasks/push_strings.yml
+++ b/roles/post_translation/tasks/push_strings.yml
@@ -2,9 +2,10 @@
 
 - name: Add files to pr_branch & push the files
   ansible.builtin.shell: |
-    cd {{ clone_directory.path }} &&\
-    git restore {{ shell_script_path }} && \
+    cd {{ clone_directory.path }} && \
     git add . && \
+    git reset -- {{ shell_script_path }} && \
+    git reset -- tools && \
     git commit -m "Pushing updated strings for localization" && \
     git push origin {{ pr_branch }}
   changed_when: false


### PR DESCRIPTION
When the post_translations.sh does not exist in the repo, the "git restore" command fails.  This ignores that error in those cases. 

Here is an example of the failure:

```
TASK [post_translation : Add files to pr_branch & push the files] ***************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "cmd": "cd /home/chadams/ansible-collection-memsource/roles/post_translation/files/_clones/galaxy_ng || true && git restore tools/scripts/l18n/post_translation.sh && git add . && git commit -m \"Pushing updated strings for localization\" && git push origin translations_updated_2022-11-09_13_20_21\n", "delta": "0:00:00.005007", "end": "2022-11-09 13:20:58.808801", "msg": "non-zero return code", "rc": 1, "start": "2022-11-09 13:20:58.803794", "stderr": "error: pathspec 'tools/scripts/l18n/post_translation.sh' did not match any file(s) known to git", "stderr_lines": ["error: pathspec 'tools/scripts/l18n/post_translation.sh' did not match any file(s) known to git"], "stdout": "", "stdout_lines": []}
```