### PR TITLE
updated commit_message for post_translation as var

### DIFF
--- a/extra_vars.yml
+++ b/extra_vars.yml
@@ -1,13 +1,17 @@
 ---
 # Template vars file
 github_username: ""
-github_token: ""
 repo_url: ""
 repo_branch: ""
 fork_repo_url: ""
-shell_script_path: ""
 project_name: ""
-project_template:
+project_template: ""
 memsource_username: ""
 memsource_password: ""
 languages:
+
+# Uncomment and update string to override defaults
+# shell_script_path: ""
+# commit_message: ""
+# github_token: ""
+# project_uid

--- a/roles/post_translation/README.md
+++ b/roles/post_translation/README.md
@@ -12,15 +12,16 @@ Requirements
 Role Variables
 --------------
 
-Below are the mandatory variables required.
+Below are the variables required for the role. (Default variables can be overridden)
 - memsource_username (Can be provided from the command-line, vars file or can be set in environment variables) - (Type: str)
 - memsource_password (Can be provided from the command-line, vars file or can be set in environment variables) - (Type: str)
 - github_username - (Type: str)
-- repo_url - (Type: str)
+- repo_url - (Type: str) (e.g. ansible/pinakes-ui)
 - repo_branch - (Type: str)
 - fork_repo_url - (Type: str) (Please note, a fork of the main repository URL should already be present for the github_username specified)
 - languages - (Type: list)
-- shell_script_path (Default (tools/scripts/l18n/post_translation.sh) - can be overridden) (Type: str)
+- shell_script_path (Default: tools/scripts/l18n/post_translation.sh) (Type: str)
+- commit_message (Default: Pushing updated strings for localization)
 - project_name - (Type: str) (Optional: Either pass project_name or project_uid)
 - project_uid - (Type: int) (Optional) - (WARNING: Do not include in pre_translation role as it will
 fail)

--- a/roles/post_translation/defaults/main.yml
+++ b/roles/post_translation/defaults/main.yml
@@ -2,6 +2,7 @@
 memsource_username: "{{ lookup('env', 'MEMSOURCE_USERNAME') }}"
 memsource_password: "{{ lookup('env', 'MEMSOURCE_PASSWORD') }}"
 shell_script_path: "tools/scripts/l18n/post_translation.sh"
+commit_message: "Pushing updated strings for localization"
 languages:
 github_username: ""
 github_token: ""

--- a/roles/post_translation/tasks/push_strings.yml
+++ b/roles/post_translation/tasks/push_strings.yml
@@ -6,7 +6,7 @@
     git add . && \
     git reset -- {{ shell_script_path }} && \
     git reset -- tools && \
-    git commit -m "Pushing updated strings for localization" && \
+    git commit -m "{{ commit_message }}" && \
     git push origin {{ pr_branch }}
   changed_when: false
 

--- a/roles/pre_translation/README.md
+++ b/roles/pre_translation/README.md
@@ -11,15 +11,15 @@ A shell script in the repository to move the translated strings and it's path to
 Role Variables
 --------------
 
-Below are the mandatory variables required.
+Below are the variables required for the role. (Default variables can be overridden)
 - memsource_username (Can be provided from the command-line, vars file or can be set in environment variables) - (Type: str)
 - memsource_password (Can be provided from the command-line, vars file or can be set in environment variables) - (Type: str)
 - languages - (Type: list)
 - shell_script_path (Default (tools/scripts/l18n/pre_translation.sh) - can be overridden) (Type: str)
-- repo_url - (Type: str)
+- repo_url - (Type: str) (e.g. ansible/pinakes-ui)
 - repo_branch - (Type: str)
 - project_name - (Type: str)
-- project_template (Required: Project template dedicated to the specific project to be translated) - (Type: int)
+- project_template (Required: Project template dedicated to the specific project to be translated) - (Type: str)
 - pre_translate (Default: true | Optional: Certain translations will be pre_translated from cached memsource database, until stated false) - (Type: bool)
 
 Optional parameters


### PR DESCRIPTION
The following PR is related to the issue [https://github.com/ansible/ansible-collection-memsource/issues/51]

Below are some applicable changes:
- Removed the static commit_message "Pushing updated strings for localization" to a var {commit_message} to be overridden in post_translation role
- If commit_message is not provided as extra arguments while running post_translation role, it will use the default string ("Pushing updated strings for localization")
- Updated both README.md for pre/ post_translation 