### PR TITLE
Add script path var to template file and dynamically get dirname

### DIFF
--- a/extra_vars.yml
+++ b/extra_vars.yml
@@ -12,6 +12,7 @@ languages:
 
 # Uncomment and update string to override defaults
 # shell_script_path: ""
+# local_shell_script_path: "/custom/local/script.sh"
 # commit_message: ""
 # github_token: ""
-# project_uid
+# project_uid: ""

--- a/roles/post_translation/tasks/main.yml
+++ b/roles/post_translation/tasks/main.yml
@@ -9,6 +9,7 @@
       - repo_branch | default('') | length
       - github_username | default('') | length
       - project_name | default('') | length
+      - commit_message | default('') | length
 
 - name: Download strings from Memsource
   ansible.builtin.include_tasks: download_from_memsource.yml

--- a/roles/post_translation/tasks/move_translated_strings.yml
+++ b/roles/post_translation/tasks/move_translated_strings.yml
@@ -60,7 +60,7 @@
   block:
     - name: Create tools/scripts/l18n directory if needed
       ansible.builtin.file:
-        path: "{{ clone_directory.path }}/tools/scripts/l18n"
+        path: "{{ clone_directory.path }}/{{ shell_script_path | dirname }}"
         state: directory
         mode: 0775
 


### PR DESCRIPTION
I realized I didn't add the local_shell_script_path variable to the extra_vars.yml template file.  

I also:
* added an assertion so that even if set, it is never an empty string (as things will fail)
* dynamically determine the dirname of the script when creating the dir and setting permissions on it rather than hardcoding it.  